### PR TITLE
Update 5.-SymbolicOperations_and_CLBM.md

### DIFF
--- a/docs/tutorials/model-development/5.-SymbolicOperations_and_CLBM.md
+++ b/docs/tutorials/model-development/5.-SymbolicOperations_and_CLBM.md
@@ -50,7 +50,7 @@ The physical interpretation of the raw, zeroth order moments of the hydrodynamic
 $$
 \begin{eqnarray} 
 \rho &=& k_{00} = \sum_\alpha f_\alpha, \\
-\rho H &=& k_{00}^H = \sum_\alpha h_\alpha,
+\rho c_p T &=& k_{00}^H = \sum_\alpha h_\alpha,
 \end{eqnarray}
 $$
 


### PR DESCRIPTION
fixing typo: \rho H --> \rho c_p T